### PR TITLE
Fix training issues and upgrade dependencies

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,7 @@
   "permissions": {
     "allow": [
       "Bash(cargo check:*)",
+      "Bash(cargo build:*)",
       "Bash(cargo test:*)",
       "Bash(cargo clippy:*)"
     ],

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(cargo check:*)",
+      "Bash(cargo test:*)",
+      "Bash(cargo clippy:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build and Development Commands
+
+```bash
+# Build all crates
+just build   # or: just b
+
+# Format and lint
+just clippy  # or: just c, just check
+
+# Run nanogpt training
+just train   # Runs with RUST_LOG=info
+
+# Run tests
+cargo test                           # All tests
+cargo test -p nanogpt               # Tests for specific crate
+cargo test test_name                # Single test by name
+
+# Download MNIST data (required for nanodiffuse)
+just setup-mnist
+```
+
+## Architecture
+
+This is a Rust workspace containing toy implementations of ML models using [candle](https://github.com/huggingface/candle) for tensor operations.
+
+### Crates
+
+- **nanogpt** - GPT-style transformer language model
+  - `model/mod.rs` - `BigramModel` with token/position embeddings, transformer blocks, and language model head
+  - `model/block.rs` - Transformer blocks with multi-head self-attention
+  - `dataset.rs` - Training/validation data batching
+  - Uses `nanotok` for tokenization
+
+- **nanodiffuse** - Toy diffusion model (WIP)
+  - `model.rs` - Basic U-Net with convolutional down/up paths
+  - `lib.rs` - MNIST loading, image corruption for diffusion training
+  - `util.rs` - Tensor-to-BMP image output for visualization
+
+- **nanotok** - BPE tokenizer implementations
+  - `tokenizers/basic.rs` - Basic BPE tokenizer
+  - `tokenizers/regex.rs` - Regex-based tokenizer (GPT-2/4 style patterns)
+  - `Tokenizer` trait: `train`, `encode`, `decode`, `save`, `load`
+
+### Hardware Acceleration
+
+Candle is configured per-platform in each crate's Cargo.toml:
+- macOS: Metal backend
+- Windows/Linux: CUDA backend
+- CPU fallback via `--gpu` flag (default is CPU)
+
+### Configuration
+
+nanogpt reads `config.toml` for training config and hyperparameters. See `TrainingConfig` and `Hyperparams` structs in `model/mod.rs` for available options.
+
+### Data Paths
+
+- LLM training data: `./data/llm/` (default: `input.txt` - Shakespeare)
+  - `input.txt` - Tiny Shakespeare (~1.1 MB)
+  - `simple.txt` - Simple text (~361 KB)
+  - `taylorswift.txt` - Taylor Swift lyrics (~181 KB)
+  - `wikitext2.txt` - Wikipedia articles (~10 MB, not in git)
+  - `tinystories.txt` - Simple stories (~2.1 GB, not in git)
+- MNIST images: `./data/images/mnist/` (download via `just setup-mnist`)
+- Model checkpoints: `./models/`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,15 +88,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
 
 [[package]]
-name = "arbitrary"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
-dependencies = [
- "derive_arbitrary",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,9 +128,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bindgen_cuda"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f8489af5b7d17a81bffe37e0f4d6e1e4de87c87329d05447f22c35d95a1227d"
+checksum = "282be55fb326843bb67cccceeeaf21c961ef303f60018f9a2ab69494dad8eaf9"
 dependencies = [
  "glob",
  "num_cpus",
@@ -189,6 +186,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bstr"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,64 +245,84 @@ checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
 name = "candle-core"
-version = "0.7.2"
-source = "git+https://github.com/huggingface/candle.git#7ac0de15a9fafe59d9f97fb6d90662790488433e"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c15b675b80d994b2eadb20a4bbe434eabeb454eac3ee5e2b4cf6f147ee9be091"
 dependencies = [
  "byteorder",
  "candle-kernels",
  "candle-metal-kernels",
- "cudarc",
- "gemm",
+ "candle-ug",
+ "cudarc 0.19.0",
+ "float8 0.6.0",
+ "gemm 0.19.0",
  "half",
+ "libm",
  "memmap2",
- "metal 0.27.0",
  "num-traits",
  "num_cpus",
- "rand",
+ "objc2-foundation",
+ "objc2-metal",
+ "rand 0.9.2",
  "rand_distr",
  "rayon",
- "safetensors",
- "thiserror 1.0.65",
- "ug",
- "ug-cuda",
- "ug-metal",
- "yoke",
+ "safetensors 0.7.0",
+ "thiserror 2.0.7",
+ "yoke 0.8.1",
  "zip",
 ]
 
 [[package]]
 name = "candle-kernels"
-version = "0.7.2"
-source = "git+https://github.com/huggingface/candle.git#7ac0de15a9fafe59d9f97fb6d90662790488433e"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8455f84bd810047c7c41216683c1020c915a9f8a740b3b0eabdd4fb2fbaa660"
 dependencies = [
  "bindgen_cuda",
 ]
 
 [[package]]
 name = "candle-metal-kernels"
-version = "0.7.2"
-source = "git+https://github.com/huggingface/candle.git#7ac0de15a9fafe59d9f97fb6d90662790488433e"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fdfe9d06de16ce49961e49084e5b79a75a9bdf157246e7c7b6328e87a7aa25d"
 dependencies = [
- "metal 0.27.0",
+ "half",
+ "objc2",
+ "objc2-foundation",
+ "objc2-metal",
  "once_cell",
- "thiserror 1.0.65",
+ "thiserror 2.0.7",
  "tracing",
 ]
 
 [[package]]
 name = "candle-nn"
-version = "0.7.2"
-source = "git+https://github.com/huggingface/candle.git#7ac0de15a9fafe59d9f97fb6d90662790488433e"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3045fa9e7aef8567d209a27d56b692f60b96f4d0569f4c3011f8ca6715c65e03"
 dependencies = [
  "candle-core",
  "candle-metal-kernels",
  "half",
- "metal 0.27.0",
+ "libc",
  "num-traits",
+ "objc2-metal",
  "rayon",
- "safetensors",
+ "safetensors 0.7.0",
  "serde",
- "thiserror 1.0.65",
+ "thiserror 2.0.7",
+]
+
+[[package]]
+name = "candle-ug"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c22d62be69068bf58987a45f690612739d8d2ea1bf508c1b87dc6815a019575d"
+dependencies = [
+ "ug",
+ "ug-cuda",
+ "ug-metal",
 ]
 
 [[package]]
@@ -402,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -442,10 +468,21 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "cudarc"
-version = "0.12.1"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cd60a9a42ec83a2ed7effb0b1f073270264ea99da7acfc44f7e8d74dee0384"
+checksum = "0bf99ab37ee7072d64d906aa2dada9a3422f1d975cdf8c8055a573bc84897ed8"
 dependencies = [
+ "half",
+ "libloading",
+]
+
+[[package]]
+name = "cudarc"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d5be1e9776a20360ca270df637b391c85d48ea57508140f30a4e8f6da91884a"
+dependencies = [
+ "float8 0.3.0",
  "half",
  "libloading",
 ]
@@ -481,17 +518,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "derive_arbitrary"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
-dependencies = [
- "proc-macro2",
  "quote",
  "syn",
 ]
@@ -549,6 +575,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+dependencies = [
+ "bitflags 2.6.0",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,13 +597,19 @@ dependencies = [
 
 [[package]]
 name = "dyn-stack"
-version = "0.10.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e53799688f5632f364f8fb387488dd05db9fe45db7011be066fc20e7027f8b"
+checksum = "1c4713e43e2886ba72b8271aa66c93d722116acf7a75555cce11dcde84388fe8"
 dependencies = [
  "bytemuck",
- "reborrow",
+ "dyn-stack-macros",
 ]
+
+[[package]]
+name = "dyn-stack-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
 name = "either"
@@ -670,10 +712,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "float8"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f498aec3b227cd892ce18967f4033d9d397d28a80a7ab67e9f6b0176a79654e"
+dependencies = [
+ "half",
+]
+
+[[package]]
+name = "float8"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f463a8a37ede13dac13316d1a1eeafa992300906a0c4c7fa1177f366d10bcbf"
+dependencies = [
+ "cudarc 0.19.0",
+ "half",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_distr",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -728,17 +798,37 @@ dependencies = [
 
 [[package]]
 name = "gemm"
-version = "0.17.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ab24cc62135b40090e31a76a9b2766a501979f3070fa27f689c27ec04377d32"
+checksum = "ab96b703d31950f1aeddded248bc95543c9efc7ac9c4a21fda8703a83ee35451"
 dependencies = [
  "dyn-stack",
- "gemm-c32",
- "gemm-c64",
- "gemm-common",
- "gemm-f16",
- "gemm-f32",
- "gemm-f64",
+ "gemm-c32 0.18.2",
+ "gemm-c64 0.18.2",
+ "gemm-common 0.18.2",
+ "gemm-f16 0.18.2",
+ "gemm-f32 0.18.2",
+ "gemm-f64 0.18.2",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa0673db364b12263d103b68337a68fbecc541d6f6b61ba72fe438654709eacb"
+dependencies = [
+ "dyn-stack",
+ "gemm-c32 0.19.0",
+ "gemm-c64 0.19.0",
+ "gemm-common 0.19.0",
+ "gemm-f16 0.19.0",
+ "gemm-f32 0.19.0",
+ "gemm-f64 0.19.0",
  "num-complex",
  "num-traits",
  "paste",
@@ -748,12 +838,27 @@ dependencies = [
 
 [[package]]
 name = "gemm-c32"
-version = "0.17.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9c030d0b983d1e34a546b86e08f600c11696fde16199f971cd46c12e67512c0"
+checksum = "f6db9fd9f40421d00eea9dd0770045a5603b8d684654816637732463f4073847"
 dependencies = [
  "dyn-stack",
- "gemm-common",
+ "gemm-common 0.18.2",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c32"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "086936dbdcb99e37aad81d320f98f670e53c1e55a98bee70573e83f95beb128c"
+dependencies = [
+ "dyn-stack",
+ "gemm-common 0.19.0",
  "num-complex",
  "num-traits",
  "paste",
@@ -763,12 +868,27 @@ dependencies = [
 
 [[package]]
 name = "gemm-c64"
-version = "0.17.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbb5f2e79fefb9693d18e1066a557b4546cd334b226beadc68b11a8f9431852a"
+checksum = "dfcad8a3d35a43758330b635d02edad980c1e143dc2f21e6fd25f9e4eada8edf"
 dependencies = [
  "dyn-stack",
- "gemm-common",
+ "gemm-common 0.18.2",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c64"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c8aeeeec425959bda4d9827664029ba1501a90a0d1e6228e48bef741db3a3f"
+dependencies = [
+ "dyn-stack",
+ "gemm-common 0.19.0",
  "num-complex",
  "num-traits",
  "paste",
@@ -778,18 +898,40 @@ dependencies = [
 
 [[package]]
 name = "gemm-common"
-version = "0.17.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2e7ea062c987abcd8db95db917b4ffb4ecdfd0668471d8dc54734fdff2354e8"
+checksum = "a352d4a69cbe938b9e2a9cb7a3a63b7e72f9349174a2752a558a8a563510d0f3"
 dependencies = [
  "bytemuck",
  "dyn-stack",
  "half",
+ "libm",
  "num-complex",
  "num-traits",
  "once_cell",
  "paste",
- "pulp",
+ "pulp 0.21.5",
+ "raw-cpuid",
+ "rayon",
+ "seq-macro",
+ "sysctl",
+]
+
+[[package]]
+name = "gemm-common"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88027625910cc9b1085aaaa1c4bc46bb3a36aad323452b33c25b5e4e7c8e2a3e"
+dependencies = [
+ "bytemuck",
+ "dyn-stack",
+ "half",
+ "libm",
+ "num-complex",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "pulp 0.22.2",
  "raw-cpuid",
  "rayon",
  "seq-macro",
@@ -798,13 +940,31 @@ dependencies = [
 
 [[package]]
 name = "gemm-f16"
-version = "0.17.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca4c06b9b11952071d317604acb332e924e817bd891bec8dfb494168c7cedd4"
+checksum = "cff95ae3259432f3c3410eaa919033cd03791d81cebd18018393dc147952e109"
 dependencies = [
  "dyn-stack",
- "gemm-common",
- "gemm-f32",
+ "gemm-common 0.18.2",
+ "gemm-f32 0.18.2",
+ "half",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "rayon",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f16"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3df7a55202e6cd6739d82ae3399c8e0c7e1402859b30e4cb780e61525d9486e"
+dependencies = [
+ "dyn-stack",
+ "gemm-common 0.19.0",
+ "gemm-f32 0.19.0",
  "half",
  "num-complex",
  "num-traits",
@@ -816,12 +976,27 @@ dependencies = [
 
 [[package]]
 name = "gemm-f32"
-version = "0.17.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9a69f51aaefbd9cf12d18faf273d3e982d9d711f60775645ed5c8047b4ae113"
+checksum = "bc8d3d4385393304f407392f754cd2dc4b315d05063f62cf09f47b58de276864"
 dependencies = [
  "dyn-stack",
- "gemm-common",
+ "gemm-common 0.18.2",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f32"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e0b8c9da1fbec6e3e3ab2ce6bc259ef18eb5f6f0d3e4edf54b75f9fd41a81c"
+dependencies = [
+ "dyn-stack",
+ "gemm-common 0.19.0",
  "num-complex",
  "num-traits",
  "paste",
@@ -831,12 +1006,27 @@ dependencies = [
 
 [[package]]
 name = "gemm-f64"
-version = "0.17.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa397a48544fadf0b81ec8741e5c0fba0043008113f71f2034def1935645d2b0"
+checksum = "35b2a4f76ce4b8b16eadc11ccf2e083252d8237c1b589558a49b0183545015bd"
 dependencies = [
  "dyn-stack",
- "gemm-common",
+ "gemm-common 0.18.2",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f64"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "056131e8f2a521bfab322f804ccd652520c79700d81209e9d9275bbdecaadc6a"
+dependencies = [
+ "dyn-stack",
+ "gemm-common 0.19.0",
  "num-complex",
  "num-traits",
  "paste",
@@ -856,6 +1046,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,16 +1071,17 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "half"
-version = "2.4.1"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "bytemuck",
  "cfg-if",
  "crunchy",
  "num-traits",
- "rand",
+ "rand 0.9.2",
  "rand_distr",
+ "zerocopy 0.8.35",
 ]
 
 [[package]]
@@ -886,6 +1089,19 @@ name = "hashbrown"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "heck"
@@ -915,7 +1131,7 @@ dependencies = [
  "indicatif",
  "log",
  "native-tls",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "thiserror 1.0.65",
@@ -935,7 +1151,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
 dependencies = [
  "displaydoc",
- "yoke",
+ "yoke 0.7.4",
  "zerofrom",
  "zerovec",
 ]
@@ -1030,7 +1246,7 @@ dependencies = [
  "stable_deref_trait",
  "tinystr",
  "writeable",
- "yoke",
+ "yoke 0.7.4",
  "zerofrom",
  "zerovec",
 ]
@@ -1080,7 +1296,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.0",
 ]
 
 [[package]]
@@ -1171,9 +1387,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.11"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -1256,21 +1472,6 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43f73953f8cbe511f021b58f18c3ce1c3d1ae13fe953293e13345bf83217f25"
-dependencies = [
- "bitflags 2.6.0",
- "block",
- "core-graphics-types",
- "foreign-types 0.5.0",
- "log",
- "objc",
- "paste",
-]
-
-[[package]]
-name = "metal"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
@@ -1344,7 +1545,7 @@ dependencies = [
  "log",
  "nanotok",
  "pretty_env_logger",
- "rand",
+ "rand 0.8.5",
  "rand_pcg",
  "serde",
  "thiserror 2.0.7",
@@ -1484,27 +1685,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_enum"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
-dependencies = [
- "num_enum_derive",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1517,16 +1697,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
  "malloc_buf",
- "objc_exception",
 ]
 
 [[package]]
-name = "objc_exception"
-version = "0.1.2"
+name = "objc2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
+checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
 dependencies = [
- "cc",
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.6.0",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -1540,9 +1763,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "onig"
@@ -1675,7 +1898,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -1689,15 +1912,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
-dependencies = [
- "toml_edit",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1708,24 +1922,55 @@ dependencies = [
 
 [[package]]
 name = "pulp"
-version = "0.18.22"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0a01a0dc67cf4558d279f0c25b0962bd08fc6dec0137699eae304103e882fe6"
+checksum = "96b86df24f0a7ddd5e4b95c94fc9ed8a98f1ca94d3b01bdce2824097e7835907"
 dependencies = [
  "bytemuck",
+ "cfg-if",
  "libm",
  "num-complex",
  "reborrow",
+ "version_check",
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.37"
+name = "pulp"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "2e205bb30d5b916c55e584c22201771bcf2bad9aabd5d4127f38387140c38632"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "paste",
+ "pulp-wasm-simd-flag",
+ "raw-cpuid",
+ "reborrow",
+ "version_check",
+]
+
+[[package]]
+name = "pulp-wasm-simd-flag"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40e24eee682d89fb193496edf918a7f407d30175b2e785fe057e4392dfd182e0"
+
+[[package]]
+name = "quote"
+version = "1.0.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -1734,8 +1979,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1745,7 +2000,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1754,17 +2019,26 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
 name = "rand_distr"
-version = "0.4.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.9.2",
 ]
 
 [[package]]
@@ -1773,16 +2047,16 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "raw-cpuid"
-version = "10.7.0"
+version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -1837,7 +2111,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.65",
 ]
@@ -1879,7 +2153,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "spin",
  "untrusted",
@@ -1966,6 +2240,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "safetensors"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "675656c1eabb620b921efea4f9199f97fc86e36dd6ffd1fbbe48d0f59a4987f5"
+dependencies = [
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2020,18 +2305,28 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.214"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.214"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2169,9 +2464,9 @@ dependencies = [
 
 [[package]]
 name = "sysctl"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7dddc5f0fee506baf8b9fdb989e242f17e4b11c61dfbb0635b705217199eea"
+checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
 dependencies = [
  "bitflags 2.6.0",
  "byteorder",
@@ -2278,7 +2573,7 @@ dependencies = [
  "aho-corasick",
  "derive_builder",
  "esaxx-rs",
- "getrandom",
+ "getrandom 0.2.15",
  "hf-hub",
  "indicatif",
  "itertools 0.12.1",
@@ -2288,7 +2583,7 @@ dependencies = [
  "monostate",
  "onig",
  "paste",
- "rand",
+ "rand 0.8.5",
  "rayon",
  "rayon-cond",
  "regex",
@@ -2367,9 +2662,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -2378,9 +2673,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2389,51 +2684,63 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
-name = "ug"
-version = "0.0.2"
+name = "typed-path"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4eef2ebfc18c67a6dbcacd9d8a4d85e0568cc58c82515552382312c2730ea13"
+checksum = "3015e6ce46d5ad8751e4a772543a30c7511468070e98e64e20165f8f81155b64"
+
+[[package]]
+name = "ug"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76b761acf8af3494640d826a8609e2265e19778fb43306c7f15379c78c9b05b0"
 dependencies = [
+ "gemm 0.18.2",
  "half",
+ "libloading",
+ "memmap2",
  "num",
+ "num-traits",
+ "num_cpus",
+ "rayon",
+ "safetensors 0.4.5",
  "serde",
- "serde_json",
  "thiserror 1.0.65",
+ "tracing",
+ "yoke 0.7.4",
 ]
 
 [[package]]
 name = "ug-cuda"
-version = "0.0.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c4dcab280ad0ef3957e153a82dcad608c954d02cf253b695322f502d1f8902e"
+checksum = "9f0a1fa748f26166778c33b8498255ebb7c6bffb472bcc0a72839e07ebb1d9b5"
 dependencies = [
- "cudarc",
+ "cudarc 0.17.8",
  "half",
  "serde",
- "serde_json",
  "thiserror 1.0.65",
  "ug",
 ]
 
 [[package]]
 name = "ug-metal"
-version = "0.0.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4ed1df2c20a1a138f993041f650cc84ff27aaefb4342b7f986e77d00e80799"
+checksum = "9f7adf545a99a086d362efc739e7cf4317c18cbeda22706000fd434d70ea3d95"
 dependencies = [
  "half",
- "metal 0.29.0",
+ "metal",
  "objc",
  "serde",
- "serde_json",
  "thiserror 1.0.65",
  "ug",
 ]
@@ -2538,6 +2845,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2552,6 +2865,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -2793,6 +3115,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2812,7 +3140,18 @@ checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
 dependencies = [
  "serde",
  "stable_deref_trait",
- "yoke-derive",
+ "yoke-derive 0.7.4",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive 0.8.1",
  "zerofrom",
 ]
 
@@ -2829,13 +3168,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdea86ddd5568519879b8187e1cf04e24fce28f7fe046ceecbce472ff19a2572"
+dependencies = [
+ "zerocopy-derive 0.8.35",
 ]
 
 [[package]]
@@ -2843,6 +3203,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c15e1b46eff7c6c91195752e0eeed8ef040e391cdece7c25376957d5f15df22"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2882,7 +3253,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
 dependencies = [
- "yoke",
+ "yoke 0.7.4",
  "zerofrom",
  "zerovec-derive",
 ]
@@ -2900,15 +3271,12 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "1.1.4"
+version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cc23c04387f4da0374be4533ad1208cbb091d5c11d070dfef13676ad6497164"
+checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
 dependencies = [
- "arbitrary",
  "crc32fast",
- "crossbeam-utils",
- "displaydoc",
  "indexmap",
- "num_enum",
- "thiserror 1.0.65",
+ "memchr",
+ "typed-path",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy 0.8.35",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,12 +127,6 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -326,6 +334,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,16 +404,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
 name = "console"
 version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
 dependencies = [
- "encode_unicode",
+ "encode_unicode 0.3.6",
  "lazy_static",
  "libc",
  "unicode-width 0.1.14",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "console"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
+dependencies = [
+ "encode_unicode 1.0.0",
+ "libc",
+ "once_cell",
+ "unicode-width 0.2.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -523,6 +568,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dary_heap"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,23 +609,23 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "5.0.1"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -624,6 +678,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,16 +715,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
-name = "errno"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "esaxx-rs"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,20 +736,14 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.14.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
 dependencies = [
  "bit-set 0.8.0",
  "regex-automata",
  "regex-syntax",
 ]
-
-[[package]]
-name = "fastrand"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
 
 [[package]]
 name = "flate2"
@@ -747,21 +791,12 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared 0.3.1",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -774,12 +809,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1086,12 +1115,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
@@ -1123,19 +1146,31 @@ checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hf-hub"
-version = "0.3.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b780635574b3d92f036890d8373433d6f9fc7abb320ee42a5c25897fc8ed732"
+checksum = "629d8f3bbeda9d148036d6b0de0a3ab947abd08ce90626327fc3547a49d59d97"
 dependencies = [
  "dirs",
- "indicatif",
+ "http",
+ "indicatif 0.17.9",
+ "libc",
  "log",
- "native-tls",
- "rand 0.8.5",
+ "rand 0.9.2",
  "serde",
  "serde_json",
- "thiserror 1.0.65",
+ "thiserror 2.0.7",
  "ureq",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
 ]
 
 [[package]]
@@ -1291,12 +1326,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.6.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.0",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1305,10 +1340,23 @@ version = "0.17.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbf675b85ed934d3c67b5c5469701eec7db22689d0a2139d856e0925fa28b281"
 dependencies = [
- "console",
+ "console 0.15.8",
  "number_prefix",
  "portable-atomic",
  "unicode-width 0.2.0",
+ "web-time",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9375e112e4b463ec1b1c6c011953545c65a30164fbab5b581df32b3abf0dcb88"
+dependencies = [
+ "console 0.16.2",
+ "portable-atomic",
+ "unicode-width 0.2.0",
+ "unit-prefix",
  "web-time",
 ]
 
@@ -1331,18 +1379,9 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1400,12 +1439,6 @@ dependencies = [
  "bitflags 2.6.0",
  "libc",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "litemap"
@@ -1479,7 +1512,7 @@ dependencies = [
  "bitflags 2.6.0",
  "block",
  "core-graphics-types",
- "foreign-types 0.5.0",
+ "foreign-types",
  "log",
  "objc",
  "paste",
@@ -1559,7 +1592,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "fancy-regex 0.14.0",
+ "fancy-regex 0.17.0",
  "indexmap",
  "log",
  "pretty_env_logger",
@@ -1570,23 +1603,6 @@ dependencies = [
  "tiktoken-rs",
  "tokenizers",
  "tokio",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -1769,11 +1785,11 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "onig"
-version = "6.4.0"
+version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c4b31c8722ad9171c6d77d3557db078cab2bd50afcc9d09c8b315c59df8ca4f"
+checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "libc",
  "once_cell",
  "onig_sys",
@@ -1781,56 +1797,12 @@ dependencies = [
 
 [[package]]
 name = "onig_sys"
-version = "69.8.1"
+version = "69.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b829e3d7e9cc74c7e315ee8edb185bf4190da5acde74afd7fc59c35b1f086e7"
+checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
 dependencies = [
  "cc",
  "pkg-config",
-]
-
-[[package]]
-name = "openssl"
-version = "0.10.68"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
-dependencies = [
- "bitflags 2.6.0",
- "cfg-if",
- "foreign-types 0.3.2",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -2071,12 +2043,12 @@ dependencies = [
 
 [[package]]
 name = "rayon-cond"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "059f538b55efd2309c9794130bc149c6a553db90e9d99c2030785c82f0bd7df9"
+checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
 dependencies = [
  "either",
- "itertools 0.11.0",
+ "itertools",
  "rayon",
 ]
 
@@ -2107,13 +2079,13 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.6"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
- "thiserror 1.0.65",
+ "thiserror 2.0.7",
 ]
 
 [[package]]
@@ -2171,19 +2143,6 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustix"
-version = "0.38.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
-dependencies = [
- "bitflags 2.6.0",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "rustls"
@@ -2245,7 +2204,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "675656c1eabb620b921efea4f9199f97fc86e36dd6ffd1fbbe48d0f59a4987f5"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown",
  "serde",
  "serde_json",
 ]
@@ -2260,42 +2219,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.6.0",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "seq-macro"
@@ -2347,11 +2274,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2386,6 +2313,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2408,6 +2346,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -2477,19 +2421,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
-dependencies = [
- "cfg-if",
- "fastrand",
- "once_cell",
- "rustix",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2540,16 +2471,15 @@ dependencies = [
 
 [[package]]
 name = "tiktoken-rs"
-version = "0.6.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44075987ee2486402f0808505dd65692163d243a337fc54363d49afac41087f6"
+checksum = "3a19830747d9034cd9da43a60eaa8e552dfda7712424aebf187b7a60126bae0d"
 dependencies = [
  "anyhow",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bstr",
  "fancy-regex 0.13.0",
  "lazy_static",
- "parking_lot",
  "regex",
  "rustc-hash",
 ]
@@ -2566,24 +2496,26 @@ dependencies = [
 
 [[package]]
 name = "tokenizers"
-version = "0.21.0"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecededfed68a69bc657e486510089e255e53c3d38cc7d4d59c8742668ca2cae"
+checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
 dependencies = [
+ "ahash",
  "aho-corasick",
+ "compact_str",
+ "dary_heap",
  "derive_builder",
  "esaxx-rs",
- "getrandom 0.2.15",
+ "getrandom 0.3.4",
  "hf-hub",
- "indicatif",
- "itertools 0.12.1",
- "lazy_static",
+ "indicatif 0.18.3",
+ "itertools",
  "log",
  "macro_rules_attribute",
  "monostate",
  "onig",
  "paste",
- "rand 0.8.5",
+ "rand 0.9.2",
  "rayon",
  "rayon-cond",
  "regex",
@@ -2591,7 +2523,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spm_precompiled",
- "thiserror 1.0.65",
+ "thiserror 2.0.7",
  "unicode-normalization-alignments",
  "unicode-segmentation",
  "unicode_categories",
@@ -2628,37 +2560,42 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.9.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
 dependencies = [
- "serde",
+ "indexmap",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.22.22"
+name = "toml_parser"
+version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
 dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
  "winnow",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tracing"
@@ -2785,6 +2722,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2799,12 +2742,12 @@ dependencies = [
  "base64 0.22.1",
  "flate2",
  "log",
- "native-tls",
  "once_cell",
  "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
+ "socks",
  "url",
  "webpki-roots",
 ]
@@ -2837,12 +2780,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -2949,6 +2886,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2958,13 +2911,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-sys"
-version = "0.48.0"
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
@@ -2985,18 +2941,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.48.5"
+name = "windows-sys"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -3008,7 +2967,7 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
@@ -3016,10 +2975,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
+name = "windows-targets"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3028,10 +2998,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.5"
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3040,10 +3010,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
+name = "windows_aarch64_msvc"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3052,16 +3022,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
+name = "windows_i686_gnullvm"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3070,10 +3046,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
+name = "windows_i686_msvc"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3082,10 +3058,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.5"
+name = "windows_x86_64_gnu"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3094,10 +3070,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3106,13 +3082,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.6.20"
+name = "windows_x86_64_msvc"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
-dependencies = [
- "memchr",
-]
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,9 @@ members = ["crates/nanogpt", "crates/nanotok"]
 
 [workspace.dependencies]
 anyhow = "1.0"
-clap = { version = "4.5.23", features = ["derive"] }
-indexmap = "2.6.0"
-log = "0.4.22"
-pretty_env_logger = "0.5.0"
+clap = { version = "4.5", features = ["derive"] }
+indexmap = "2.13"
+log = "0.4"
+pretty_env_logger = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,74 @@
+# nanogpt
+
+A Rust workspace containing toy implementations of ML models using [candle](https://github.com/huggingface/candle) for tensor operations.
+
+## Crates
+
+### nanogpt
+
+GPT-style transformer language model implementation featuring:
+
+- Token and position embeddings
+- Transformer blocks with multi-head self-attention
+- Language model head for text generation
+- Configurable hyperparameters via `config.toml`
+
+### nanotok
+
+BPE tokenizer implementations:
+
+- **BasicTokenizer** - Basic BPE tokenizer
+- **RegexTokenizer** - Regex-based tokenizer (GPT-2/4 style patterns)
+
+Includes a CLI tool (`nanotok-cli`) for training and testing tokenizers.
+
+## Requirements
+
+- Rust (stable)
+- [just](https://github.com/casey/just) command runner
+
+## Quick Start
+
+```bash
+# Build all crates
+just build
+
+# Run training (uses config.toml for hyperparameters)
+just train
+
+# Format and lint
+just clippy
+```
+
+## Configuration
+
+Edit `config.toml` to adjust training parameters:
+
+```toml
+[training]
+dropout = 0.2
+learning_rate = 3e-4
+
+[hyperparams]
+batch_size = 8
+block_size = 256
+num_embed = 384
+num_heads = 4
+num_layers = 4
+```
+
+## Hardware Acceleration
+
+Candle automatically uses hardware acceleration based on platform:
+
+- **macOS**: Metal backend
+- **Windows/Linux**: CUDA backend
+- **Fallback**: CPU
+
+## Data
+
+Training data goes in `./data/llm/`. The default dataset is `input.txt` (Tiny Shakespeare).
+
+## License
+
+MIT

--- a/config.toml
+++ b/config.toml
@@ -5,6 +5,7 @@ learning_rate = 3e-4
 warmup_steps = 200
 max_grad_norm = 1.0
 weight_decay = 0.01
+checkpoint_interval = 500
 
 [hyperparams]
 batch_size = 16

--- a/config.toml
+++ b/config.toml
@@ -2,12 +2,13 @@
 dropout = 0.2
 eps = 1e-5
 learning_rate = 3e-4
+warmup_steps = 200
+max_grad_norm = 1.0
+weight_decay = 0.01
 
 [hyperparams]
-# Technically only for training but we'll keep it here.
-batch_size = 8
+batch_size = 16
 block_size = 256
-
 num_embed = 384
-num_heads = 4
-num_layers = 4
+num_heads = 6
+num_layers = 6

--- a/crates/nanogpt/Cargo.toml
+++ b/crates/nanogpt/Cargo.toml
@@ -18,9 +18,9 @@ tokio = { workspace = true }
 toml = "0.8.19"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-candle-core = { git = "https://github.com/huggingface/candle.git", version = "0.7.2", features = ["cuda"]}
-candle-nn = { git = "https://github.com/huggingface/candle.git", version = "0.7.2", features = ["cuda"] }
+candle-core = { version = "0.9.2", features = ["cuda"] }
+candle-nn = { version = "0.9.2", features = ["cuda"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-candle-core = { git = "https://github.com/huggingface/candle.git", version = "0.7.2", features = ["metal"]}
-candle-nn = { git = "https://github.com/huggingface/candle.git", version = "0.7.2", features = ["metal"] }
+candle-core = { version = "0.9.2", features = ["metal"] }
+candle-nn = { version = "0.9.2", features = ["metal"] }

--- a/crates/nanogpt/Cargo.toml
+++ b/crates/nanogpt/Cargo.toml
@@ -10,12 +10,12 @@ indexmap = { workspace = true }
 log = { workspace = true }
 nanotok = { path = "../nanotok" }
 pretty_env_logger = { workspace = true }
-rand = "0.8.5"
-rand_pcg = "0.3.1"
+rand = "0.8"
+rand_pcg = "0.3"
 serde = { workspace = true }
-thiserror = "2.0.6"
+thiserror = "2.0"
 tokio = { workspace = true }
-toml = "0.8.19"
+toml = "0.9"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 candle-core = { version = "0.9.2", features = ["cuda"] }

--- a/crates/nanogpt/src/main.rs
+++ b/crates/nanogpt/src/main.rs
@@ -280,8 +280,9 @@ fn run_training(
     num_steps: usize,
 ) -> Result<(), GptError> {
     log::info!("starting model training, running for {num_steps} steps");
-    model.train(dataset, num_steps)?;
-    log::info!("Saving model to {LATEST_MODEL_PATH}");
+    model.train(dataset, num_steps, LATEST_MODEL_PATH)?;
+    // Save final checkpoint
+    log::info!("Saving final model to {LATEST_MODEL_PATH}");
     model.parameters.save(LATEST_MODEL_PATH)?;
     Ok(())
 }

--- a/crates/nanogpt/src/model/mod.rs
+++ b/crates/nanogpt/src/model/mod.rs
@@ -1,7 +1,7 @@
 use candle_core::{DType, Device, Error, IndexOp, Result, Tensor};
 use candle_nn::{
     embedding, linear_no_bias, ops::softmax_last_dim, seq, AdamW, Embedding, LayerNorm, Linear,
-    Module, Optimizer, Sequential, VarBuilder, VarMap,
+    Module, Optimizer, ParamsAdamW, Sequential, VarBuilder, VarMap,
 };
 
 use rand::prelude::Distribution;
@@ -21,14 +21,32 @@ pub struct TrainingConfig {
     pub dropout: f32,
     pub eps: f64,
     pub learning_rate: f64,
+    #[serde(default = "default_warmup_steps")]
+    pub warmup_steps: usize,
+    #[serde(default = "default_max_grad_norm")]
+    pub max_grad_norm: f64,
+    #[serde(default = "default_weight_decay")]
+    pub weight_decay: f64,
+}
+
+fn default_warmup_steps() -> usize {
+    200
+}
+
+fn default_max_grad_norm() -> f64 {
+    1.0
+}
+
+fn default_weight_decay() -> f64 {
+    0.01
 }
 
 impl std::fmt::Display for TrainingConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "TrainingConfig: dropout={}, eps={}, learning_rate={}",
-            self.dropout, self.eps, self.learning_rate
+            "TrainingConfig: dropout={}, eps={}, lr={}, warmup={}, max_grad_norm={}, weight_decay={}",
+            self.dropout, self.eps, self.learning_rate, self.warmup_steps, self.max_grad_norm, self.weight_decay
         )
     }
 }
@@ -39,6 +57,9 @@ impl Default for TrainingConfig {
             dropout: 0.2,
             eps: 1e-5,
             learning_rate: 3e-4,
+            warmup_steps: default_warmup_steps(),
+            max_grad_norm: default_max_grad_norm(),
+            weight_decay: default_weight_decay(),
         }
     }
 }
@@ -157,11 +178,29 @@ impl BigramModel {
         let train_start = std::time::Instant::now();
         let mut timer = std::time::Instant::now();
 
-        let mut optimizer = AdamW::new_lr(
-            self.parameters.all_vars(),
-            self.config.training.learning_rate,
-        )?;
+        let warmup_steps = self.config.training.warmup_steps;
+        let max_lr = self.config.training.learning_rate;
+        let max_grad_norm = self.config.training.max_grad_norm;
+
+        // Configure AdamW with proper weight decay
+        let params = ParamsAdamW {
+            lr: if warmup_steps > 0 { 0.0 } else { max_lr },
+            beta1: 0.9,
+            beta2: 0.95, // slightly lower beta2 for transformers
+            eps: 1e-8,
+            weight_decay: self.config.training.weight_decay,
+        };
+        let mut optimizer = AdamW::new(self.parameters.all_vars(), params)?;
+
         for step in 0..num_steps {
+            // Learning rate warmup: linear increase from 0 to max_lr
+            if step < warmup_steps {
+                let lr = max_lr * (step as f64 + 1.0) / warmup_steps as f64;
+                optimizer.set_learning_rate(lr);
+            } else if step == warmup_steps {
+                optimizer.set_learning_rate(max_lr);
+            }
+
             // sample a batch of data
             let (input, target) = dataset.get_batch(
                 self.config.hyperparams.batch_size,
@@ -170,8 +209,32 @@ impl BigramModel {
             // evaluate the loss
             let logits = self.forward(&input)?;
             let loss = utils::estimate_loss(&logits, &target)?;
-            // Combines loss.backward() & optimizer.step() from pytorch.
-            optimizer.backward_step(&loss)?;
+
+            // Compute gradients
+            let mut grads = loss.backward()?;
+
+            // Gradient clipping by global norm
+            let mut total_norm_sq = 0.0f64;
+            for var in self.parameters.all_vars() {
+                if let Some(grad) = grads.get(&var) {
+                    let norm_sq = grad.sqr()?.sum_all()?.to_scalar::<f32>()? as f64;
+                    total_norm_sq += norm_sq;
+                }
+            }
+            let total_norm = total_norm_sq.sqrt();
+
+            // Scale gradients if norm exceeds max
+            if total_norm > max_grad_norm {
+                let clip_coef = max_grad_norm / (total_norm + 1e-6);
+                for var in self.parameters.all_vars() {
+                    if let Some(grad) = grads.remove(&var) {
+                        let clipped = (grad * clip_coef)?;
+                        grads.insert(&var, clipped);
+                    }
+                }
+            }
+            optimizer.step(&grads)?;
+
             // Go at least one step before printing out any stats.
             if step > 0 && (step == 1 || step % 100 == 0 || step == num_steps - 1) {
                 let train_loss = loss.to_scalar::<f32>()?;
@@ -185,8 +248,9 @@ impl BigramModel {
 
                 let tps = (timer.elapsed().as_secs_f32() / 100.0) * 1000.0;
                 timer = std::time::Instant::now();
+                let current_lr = optimizer.learning_rate();
                 log::info!(
-                    "step {step} - train loss = {train_loss:0.3}, val loss = {val_loss:0.3}, per step: {tps:0.3}ms",
+                    "step {step} - train loss = {train_loss:0.3}, val loss = {val_loss:0.3}, lr = {current_lr:.2e}, per step: {tps:0.3}ms",
                 );
             }
         }

--- a/crates/nanogpt/src/model/mod.rs
+++ b/crates/nanogpt/src/model/mod.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use candle_core::{DType, Device, Error, IndexOp, Result, Tensor};
 use candle_nn::{
     embedding, linear_no_bias, ops::softmax_last_dim, seq, AdamW, Embedding, LayerNorm, Linear,
@@ -27,6 +29,8 @@ pub struct TrainingConfig {
     pub max_grad_norm: f64,
     #[serde(default = "default_weight_decay")]
     pub weight_decay: f64,
+    #[serde(default = "default_checkpoint_interval")]
+    pub checkpoint_interval: usize,
 }
 
 fn default_warmup_steps() -> usize {
@@ -41,12 +45,16 @@ fn default_weight_decay() -> f64 {
     0.01
 }
 
+fn default_checkpoint_interval() -> usize {
+    1000
+}
+
 impl std::fmt::Display for TrainingConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "TrainingConfig: dropout={}, eps={}, lr={}, warmup={}, max_grad_norm={}, weight_decay={}",
-            self.dropout, self.eps, self.learning_rate, self.warmup_steps, self.max_grad_norm, self.weight_decay
+            "TrainingConfig: dropout={}, eps={}, lr={}, warmup={}, max_grad_norm={}, weight_decay={}, checkpoint_interval={}",
+            self.dropout, self.eps, self.learning_rate, self.warmup_steps, self.max_grad_norm, self.weight_decay, self.checkpoint_interval
         )
     }
 }
@@ -60,6 +68,7 @@ impl Default for TrainingConfig {
             warmup_steps: default_warmup_steps(),
             max_grad_norm: default_max_grad_norm(),
             weight_decay: default_weight_decay(),
+            checkpoint_interval: default_checkpoint_interval(),
         }
     }
 }
@@ -173,7 +182,12 @@ impl BigramModel {
         }
     }
 
-    pub fn train(&self, dataset: &mut Dataset, num_steps: usize) -> Result<()> {
+    pub fn train<P: AsRef<Path>>(
+        &self,
+        dataset: &mut Dataset,
+        num_steps: usize,
+        checkpoint_path: P,
+    ) -> Result<()> {
         // setup some timers for see how efficient we are.
         let train_start = std::time::Instant::now();
         let mut timer = std::time::Instant::now();
@@ -181,6 +195,7 @@ impl BigramModel {
         let warmup_steps = self.config.training.warmup_steps;
         let max_lr = self.config.training.learning_rate;
         let max_grad_norm = self.config.training.max_grad_norm;
+        let checkpoint_interval = self.config.training.checkpoint_interval;
 
         // Configure AdamW with proper weight decay
         let params = ParamsAdamW {
@@ -252,6 +267,14 @@ impl BigramModel {
                 log::info!(
                     "step {step} - train loss = {train_loss:0.3}, val loss = {val_loss:0.3}, lr = {current_lr:.2e}, per step: {tps:0.3}ms",
                 );
+            }
+
+            // Save checkpoint periodically
+            if checkpoint_interval > 0 && step > 0 && step % checkpoint_interval == 0 {
+                log::info!("Saving checkpoint at step {step}...");
+                self.parameters
+                    .save(&checkpoint_path)
+                    .expect("Failed to save checkpoint");
             }
         }
 

--- a/crates/nanotok/Cargo.toml
+++ b/crates/nanotok/Cargo.toml
@@ -6,18 +6,18 @@ edition = "2021"
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
-fancy-regex = "0.14.0"
+fancy-regex = "0.17"
 indexmap = { workspace = true }
 log = { workspace = true }
 pretty_env_logger = { workspace = true }
 serde = { workspace = true }
 serde_json = "1.0"
-strum = "0.26.3"
-strum_macros = "0.26.4"
+strum = "0.26"
+strum_macros = "0.26"
 # Only use to compare our implementation with the actual
-tiktoken-rs = "0.6.0"
-tokenizers = { version = "0.21.0", features = ["http"] }
-tokio =  { workspace = true }
+tiktoken-rs = "0.9"
+tokenizers = { version = "0.22", features = ["http"] }
+tokio = { workspace = true }
 
 [lib]
 name = "nanotok"

--- a/crates/nanotok/src/tokenizers/gpt4.rs
+++ b/crates/nanotok/src/tokenizers/gpt4.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use tiktoken_rs::{cl100k_base, CoreBPE};
@@ -37,7 +38,9 @@ impl Tokenizer for PretrainedGTP4Tokenizer {
     }
 
     fn encode(&self, text: &str) -> Vec<super::TokenSize> {
-        self.model.encode(text, Default::default())
+        let allowed_special: HashSet<&str> = HashSet::new();
+        let (tokens, _) = self.model.encode(text, &allowed_special);
+        tokens
     }
 
     fn decode(&self, tokens: &[super::TokenSize]) -> String {

--- a/crates/nanotok/src/tokenizers/regex.rs
+++ b/crates/nanotok/src/tokenizers/regex.rs
@@ -208,6 +208,7 @@ impl Tokenizer for RegexTokenizer {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
     use tiktoken_rs::cl100k_base;
 
     #[test]
@@ -215,7 +216,8 @@ mod tests {
         // Test creating a vocab with the text
         let text = "hello world!!!? (안녕하세요!) lol123 😉";
         let tokenizer = cl100k_base().unwrap();
-        let encoded = tokenizer.encode(text, Default::default());
+        let allowed_special: HashSet<&str> = HashSet::new();
+        let (encoded, _) = tokenizer.encode(text, &allowed_special);
         let decoded = tokenizer.decode(encoded).unwrap();
         assert_eq!(text, decoded);
     }

--- a/docs/TRAINING.md
+++ b/docs/TRAINING.md
@@ -1,0 +1,261 @@
+# Training Guide
+
+This document covers expected training behavior, loss values, and how to interpret them.
+
+## Configuration
+
+Default training configuration (`config.toml`):
+
+```toml
+[training]
+dropout = 0.2              # Probability of dropping neurons during training (regularization)
+eps = 1e-5                 # Small constant for numerical stability in layer normalization
+learning_rate = 3e-4       # Step size for weight updates (AdamW optimizer)
+warmup_steps = 200         # Gradually increase LR from 0 to learning_rate over this many steps
+max_grad_norm = 1.0        # Clip gradients to this maximum norm (prevents exploding gradients)
+weight_decay = 0.01        # L2 regularization strength (prevents overfitting)
+checkpoint_interval = 500  # Save model checkpoint every N steps
+
+[hyperparams]
+batch_size = 16            # Number of sequences processed in parallel per step
+block_size = 256           # Context window size (max sequence length in tokens)
+num_embed = 384            # Embedding dimension (size of token/position vectors)
+num_heads = 6              # Number of attention heads in each transformer block
+num_layers = 6             # Number of transformer blocks stacked
+```
+
+## Training Parameters Explained
+
+### dropout
+Controls how many neurons are randomly "turned off" during each training step. This prevents the model from relying too heavily on any single neuron and improves generalization.
+
+| Value | Effect |
+|-------|--------|
+| 0.0 | No dropout (may overfit) |
+| 0.1-0.2 | Light regularization (recommended for most cases) |
+| 0.3-0.5 | Heavy regularization (use for small datasets or overfitting) |
+
+### learning_rate
+How much to adjust weights based on the gradient. Too high causes instability, too low causes slow training.
+
+| Value | Use Case |
+|-------|----------|
+| 1e-3 | Aggressive, may be unstable |
+| 3e-4 | Standard for AdamW (recommended) |
+| 1e-4 | Conservative, slower but stable |
+| 1e-5 | Very slow, use for fine-tuning |
+
+### warmup_steps
+Gradually increases learning rate from 0 to avoid early training instability when the model weights are random.
+
+- **Rule of thumb**: 5-10% of total training steps
+- **Small datasets**: 100-200 steps
+- **Large datasets**: 500-2000 steps
+
+### max_grad_norm
+Clips gradients when their total norm exceeds this value. Prevents "exploding gradients" that can destabilize training.
+
+| Value | Effect |
+|-------|--------|
+| 0.5 | Aggressive clipping (very stable, slower learning) |
+| 1.0 | Standard (recommended) |
+| 5.0 | Light clipping |
+| inf | No clipping (risky) |
+
+### weight_decay
+L2 regularization that penalizes large weights, helping prevent overfitting.
+
+| Value | Effect |
+|-------|--------|
+| 0.0 | No regularization |
+| 0.01 | Light regularization (recommended) |
+| 0.1 | Strong regularization |
+
+## Hyperparameters Explained
+
+### batch_size
+Number of independent sequences processed per training step. Larger batches give more stable gradients but use more memory.
+
+| Value | Trade-off |
+|-------|-----------|
+| 4-8 | Low memory, noisy gradients |
+| 16-32 | Balanced (recommended) |
+| 64-128 | Stable gradients, high memory |
+
+**Memory scaling**: Doubling batch_size roughly doubles memory usage.
+
+### block_size (Context Window)
+Maximum number of tokens the model can "see" when making predictions. Longer context captures more dependencies but uses quadratically more memory (due to attention).
+
+| Value | Context | Memory |
+|-------|---------|--------|
+| 64 | ~10-15 words | Low |
+| 256 | ~50 words | Medium (recommended) |
+| 512 | ~100 words | High |
+| 1024+ | ~200+ words | Very high |
+
+**Memory scaling**: Doubling block_size roughly quadruples attention memory.
+
+### num_embed (Embedding Dimension)
+Size of the vector representing each token. Larger dimensions can capture more nuance but require more parameters.
+
+| Value | Parameters | Capacity |
+|-------|------------|----------|
+| 128 | Small | Limited |
+| 256 | Medium | Moderate |
+| 384 | Medium-large | Good (recommended) |
+| 512+ | Large | High |
+
+**Constraint**: Must be divisible by `num_heads` (determines head_size = num_embed / num_heads).
+
+### num_heads
+Number of parallel attention heads. Each head can learn different patterns (e.g., one for syntax, one for semantics).
+
+| Value | head_size (with num_embed=384) | Notes |
+|-------|-------------------------------|-------|
+| 4 | 96 | Fewer, larger heads |
+| 6 | 64 | Balanced (recommended, GPT-2 style) |
+| 8 | 48 | More, smaller heads |
+| 12 | 32 | Many small heads |
+
+**Common head_size**: 64 is standard (GPT-2/3 style). Ensure `num_embed % num_heads == 0`.
+
+### num_layers
+Number of stacked transformer blocks. Deeper models can learn more complex patterns but are harder to train.
+
+| Value | Capacity | Training Difficulty |
+|-------|----------|---------------------|
+| 2-4 | Low | Easy |
+| 6 | Medium | Moderate (recommended for toy models) |
+| 12 | High | Harder |
+| 24+ | Very high | Requires careful tuning |
+
+## Model Size Estimation
+
+Approximate parameter count:
+
+```
+params ≈ vocab_size × num_embed                    # Token embeddings
+       + block_size × num_embed                    # Position embeddings
+       + num_layers × (4 × num_embed² + 8 × num_embed²)  # Attention + FFN per layer
+       + vocab_size × num_embed                    # Output projection
+```
+
+For default config (vocab=65, embed=384, layers=6):
+- ~10M parameters
+
+## Scaling Guidelines
+
+### Small dataset (<1MB)
+```toml
+batch_size = 8
+block_size = 128
+num_embed = 256
+num_heads = 4
+num_layers = 4
+dropout = 0.2
+```
+
+### Medium dataset (1-10MB)
+```toml
+batch_size = 16
+block_size = 256
+num_embed = 384
+num_heads = 6
+num_layers = 6
+dropout = 0.2
+```
+
+### Large dataset (10MB+)
+```toml
+batch_size = 32
+block_size = 512
+num_embed = 512
+num_heads = 8
+num_layers = 8
+dropout = 0.1
+```
+
+## Expected Loss Progression
+
+For character-level training on Tiny Shakespeare (~1.1MB, 65 character vocabulary):
+
+| Steps | Train Loss | Val Loss | Notes |
+|-------|------------|----------|-------|
+| 0 | ~4.2 | ~4.2 | Random (ln(65)) |
+| 200 | ~3.0-3.5 | ~3.0-3.5 | End of warmup |
+| 500 | ~2.3-2.7 | ~2.4-2.8 | First checkpoint |
+| 1000 | ~1.8-2.2 | ~1.9-2.3 | Learning well |
+| 2500 | ~1.4-1.7 | ~1.5-1.8 | Good progress |
+| 5000 | ~1.2-1.5 | ~1.3-1.6 | Good stopping point |
+| 10000 | ~1.1-1.3 | ~1.2-1.5 | Diminishing returns |
+
+### Target Loss Values
+
+- **Good**: Train loss < 1.5, Val loss < 1.7
+- **Very good**: Train loss < 1.3, Val loss < 1.5
+- **Overfitting warning**: Val loss > Train loss + 0.3
+
+## Understanding Perplexity
+
+Perplexity is the exponential of the cross-entropy loss:
+
+```
+Perplexity = e^(loss)
+```
+
+### Loss to Perplexity Conversion
+
+| Loss | Perplexity | Interpretation |
+|------|------------|----------------|
+| 4.17 | 65 | Random guessing among 65 characters |
+| 2.5 | 12.2 | Choosing between ~12 likely characters |
+| 1.5 | 4.5 | Choosing between ~4-5 likely characters |
+| 1.0 | 2.7 | Choosing between ~3 likely characters |
+
+### Intuition
+
+Perplexity represents **how many choices the model is "confused" between** on average when predicting the next token.
+
+- **Perplexity of 1** = Perfect prediction (always 100% confident and correct)
+- **Perplexity of 65** = Random guessing among all 65 characters
+- **Perplexity of 4** = Model narrows prediction down to ~4 equally likely options
+
+For Tiny Shakespeare, perplexity ~4-5 (loss ~1.4-1.6) produces readable text because English has predictable patterns. For example, after "th", the model confidently predicts "e" or "a".
+
+## Training Commands
+
+```bash
+# Train with GPU (default)
+just train 5000
+
+# Train on CPU
+just gpu=false train 5000
+
+# Resume from checkpoint
+just train-resume 5000 ./models/latest.safetensors
+```
+
+## Troubleshooting
+
+### Loss stuck at ~2.5+
+
+If training loss plateaus above 2.5, check:
+
+1. **Learning rate**: Try 1e-4 or 1e-3
+2. **Warmup steps**: Ensure warmup is completing (default 200 steps)
+3. **Gradient clipping**: Verify `max_grad_norm` is set (default 1.0)
+4. **Weight decay**: Should be ~0.01
+
+### Loss explodes (NaN or very high)
+
+1. Reduce learning rate
+2. Increase warmup steps
+3. Check for numerical instability in data
+
+### Overfitting (val loss >> train loss)
+
+1. Increase dropout (try 0.3)
+2. Reduce model size (fewer layers/heads)
+3. Add more training data
+4. Stop training earlier

--- a/justfile
+++ b/justfile
@@ -10,5 +10,19 @@ clippy:
     cargo fmt
     cargo clippy
 
-train:
-    RUST_LOG=info cargo run -- train
+# train the model (default: shakespeare, 5000 steps)
+train dataset="./data/llm/input.txt" steps="5000":
+    RUST_LOG=info cargo run --release --bin nanogpt -- train --dataset-path {{dataset}} --num-steps {{steps}}
+
+# generate text from trained model
+generate tokens="256":
+    RUST_LOG=info cargo run --release --bin nanogpt -- generate --num-tokens {{tokens}}
+
+# download mnist training/testing images
+setup-mnist:
+    mkdir -p data/images/mnist
+    curl -L --remote-name --output-dir data/images/mnist "https://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz"
+    curl -L --remote-name --output-dir data/images/mnist "https://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz"
+    curl -L --remote-name --output-dir data/images/mnist "https://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz"
+    curl -L --remote-name --output-dir data/images/mnist "https://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz"
+    gunzip -k data/images/mnist/*.gz

--- a/justfile
+++ b/justfile
@@ -22,8 +22,8 @@ train-resume steps="5000" checkpoint="./models/latest.safetensors":
     RUST_LOG=info cargo run --release --bin nanogpt -- {{ if gpu == "true" { "--gpu" } else { "" } }} train --dataset-path {{dataset}} --num-steps {{steps}} --checkpoint {{checkpoint}}
 
 # generate text from trained model
-generate tokens="256":
-    RUST_LOG=info cargo run --release --bin nanogpt -- {{ if gpu == "true" { "--gpu" } else { "" } }} generate --num-tokens {{tokens}}
+generate tokens="256" prompt="":
+    RUST_LOG=info cargo run --release --bin nanogpt -- {{ if gpu == "true" { "--gpu" } else { "" } }} generate --num-tokens {{tokens}} --stream {{ if prompt != "" { "--prompt '" + prompt + "'" } else { "" } }}
 
 # train a BPE tokenizer (models: BasicTokenizer, Gpt2, Gpt4)
 train-tokenizer vocab_size="512" model="Gpt4":

--- a/justfile
+++ b/justfile
@@ -1,4 +1,5 @@
 dataset := "./data/llm/input.txt"
+gpu := "true"
 
 alias b := build
 alias c := clippy
@@ -14,15 +15,15 @@ clippy:
 
 # train the model
 train steps="5000":
-    RUST_LOG=info cargo run --release --bin nanogpt -- train --dataset-path {{dataset}} --num-steps {{steps}}
+    RUST_LOG=info cargo run --release --bin nanogpt -- {{ if gpu == "true" { "--gpu" } else { "" } }} train --dataset-path {{dataset}} --num-steps {{steps}}
 
 # resume training
 train-resume steps="5000" checkpoint="./models/latest.safetensors":
-    RUST_LOG=info cargo run --release --bin nanogpt -- train --dataset-path {{dataset}} --num-steps {{steps}} --checkpoint {{checkpoint}}
+    RUST_LOG=info cargo run --release --bin nanogpt -- {{ if gpu == "true" { "--gpu" } else { "" } }} train --dataset-path {{dataset}} --num-steps {{steps}} --checkpoint {{checkpoint}}
 
 # generate text from trained model
 generate tokens="256":
-    RUST_LOG=info cargo run --release --bin nanogpt -- generate --num-tokens {{tokens}}
+    RUST_LOG=info cargo run --release --bin nanogpt -- {{ if gpu == "true" { "--gpu" } else { "" } }} generate --num-tokens {{tokens}}
 
 # train a BPE tokenizer (models: BasicTokenizer, Gpt2, Gpt4)
 train-tokenizer vocab_size="512" model="Gpt4":

--- a/justfile
+++ b/justfile
@@ -1,3 +1,5 @@
+dataset := "./data/llm/input.txt"
+
 alias b := build
 alias c := clippy
 alias check := clippy
@@ -10,13 +12,22 @@ clippy:
     cargo fmt
     cargo clippy
 
-# train the model (default: shakespeare, 5000 steps)
-train dataset="./data/llm/input.txt" steps="5000":
+# train the model
+train steps="5000":
     RUST_LOG=info cargo run --release --bin nanogpt -- train --dataset-path {{dataset}} --num-steps {{steps}}
+
+# resume training
+train-resume steps="5000" checkpoint="./models/latest.safetensors":
+    RUST_LOG=info cargo run --release --bin nanogpt -- train --dataset-path {{dataset}} --num-steps {{steps}} --checkpoint {{checkpoint}}
 
 # generate text from trained model
 generate tokens="256":
     RUST_LOG=info cargo run --release --bin nanogpt -- generate --num-tokens {{tokens}}
+
+# train a BPE tokenizer (models: BasicTokenizer, Gpt2, Gpt4)
+train-tokenizer vocab_size="512" model="Gpt4":
+    mkdir -p models/tokenizers
+    RUST_LOG=info cargo run --release --bin nanotok-cli -- --model {{model}} train {{vocab_size}} {{dataset}}
 
 # download mnist training/testing images
 setup-mnist:


### PR DESCRIPTION
## Summary
- Add learning rate warmup, gradient clipping, and proper AdamW weight decay to improve training convergence
- Upgrade candle from 0.7.2 (git) to 0.9.2 (crates.io)
- Upgrade other dependencies: fancy-regex 0.17, tiktoken-rs 0.9, tokenizers 0.22, toml 0.9
- Fix tiktoken-rs API changes for encode() method

## Changes

### Training Improvements (`model/mod.rs`)
- **Learning rate warmup**: Linear warmup from 0 to target LR over configurable steps (default: 200)
- **Gradient clipping**: Clips gradients by global norm (default: 1.0)
- **AdamW configuration**: Explicit weight_decay (default: 0.01), beta2=0.95 for transformers
- New config options: `warmup_steps`, `max_grad_norm`, `weight_decay`

### Dependency Updates
| Package | Before | After |
|---------|--------|-------|
| candle-core/nn | 0.7.2 (git) | 0.9.2 |
| fancy-regex | 0.14 | 0.17 |
| tiktoken-rs | 0.6 | 0.9 |
| tokenizers | 0.21 | 0.22 |
| toml | 0.8 | 0.9 |
| indexmap | 2.6 | 2.13 |
| clap | 4.5.23 | 4.5 |

### Config Updates (`config.toml`)
- Added `warmup_steps = 200`
- Added `max_grad_norm = 1.0`
- Added `weight_decay = 0.01`
- Updated hyperparams: `num_heads = 6`, `num_layers = 6`, `batch_size = 16`

## Test plan
- [x] All existing tests pass
- [ ] Run `just train` to verify training improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)